### PR TITLE
Add redirects for intro/getting-started content to Learn

### DIFF
--- a/website/source/netlify-redirects
+++ b/website/source/netlify-redirects
@@ -164,4 +164,16 @@
 /intro/vs/keywhiz.html /docs/vs/keywhiz
 /intro/vs/kms.html /docs/vs/kms
 /intro/what-is-vault/index.html /docs/what-is-vault
-/intro/getting-started/install.html https://learn.hashicorp.com/vault/getting-started/install
+
+# Intro getting started content -> Learn
+/intro/getting-started/index.html https://learn.hashicorp.com/vault/getting-started/install
+/intro/getting-started/dev-server.html https://learn.hashicorp.com/vault/getting-started/dev-server
+/intro/getting-started/first-secret.html https://learn.hashicorp.com/vault/getting-started/first-secret
+/intro/getting-started/secrets-engine.html https://learn.hashicorp.com/vault/getting-started/secrets-engine
+/intro/getting-started/dynamic-secrets.html https://learn.hashicorp.com/vault/getting-started/dynamic-secrets
+/intro/getting-started/help.html https://learn.hashicorp.com/vault/getting-started/help
+/intro/getting-started/authentication.html https://learn.hashicorp.com/vault/getting-started/authentication
+/intro/getting-started/policies.html https://learn.hashicorp.com/vault/getting-started/policies
+/intro/getting-started/deploy.html https://learn.hashicorp.com/vault/getting-started/deploy
+/intro/getting-started/apis.html https://learn.hashicorp.com/vault/getting-started/apis
+/intro/getting-started/next-steps.html https://learn.hashicorp.com/vault/getting-started/next-steps


### PR DESCRIPTION
`getting-started` content under `/intro` should redirect to Learn.