### PR TITLE
website: add temporary callout to download v1.0 beta

### DIFF
--- a/website/assets/css/index.css
+++ b/website/assets/css/index.css
@@ -30,6 +30,7 @@
 @import 'pages/_docs';
 @import 'pages/_section_block';
 @import 'pages/_home';
+@import 'pages/_downloads.css';
 
 h5 {
   font-weight: 600;

--- a/website/assets/css/pages/_downloads.css
+++ b/website/assets/css/pages/_downloads.css
@@ -1,0 +1,7 @@
+#beta1-1-0 {
+  margin-bottom: 40px;
+
+  & p:last-child {
+    margin: 0px;
+  }
+}

--- a/website/source/downloads.html.erb
+++ b/website/source/downloads.html.erb
@@ -5,6 +5,8 @@ description: |-
   Download Vault
 ---
 
+<div class="alert alert-info" id="beta1-1-0" role="alert"><p><strong>1.0.0 Beta 1 Available:</strong> Binaries can be accessed on <a href="https://releases.hashicorp.com/vault/">releases.hashicorp.com</a>.</p></div>
+
 <hashi-product-downloader
   product="<%= config[:product_name] %>"
   version="<%= config[:latest_version] %>"


### PR DESCRIPTION
This adds a temporary callout to for Vault v1.0-beta to the downloads page.