### PR TITLE
website - fix broken .button-container styles

### DIFF
--- a/website/assets/css/pages/_section_block.css
+++ b/website/assets/css/pages/_section_block.css
@@ -50,8 +50,8 @@
       }
     }
 
-    & > * + .btn-container,
-    & > .g-container > * + .btn-container {
+    & > * + .button-container,
+    & > .g-container > * + .button-container {
       margin-top: 40px;
 
       @media (max-width: 767px) {


### PR DESCRIPTION
Properly sets the `.button-container` top margins to `40px` instead of `72px`.