### PR TITLE
Add analytics tracking for components and outbound links

### DIFF
--- a/website/assets/app.js
+++ b/website/assets/app.js
@@ -5,7 +5,7 @@ const extendRule = require('postcss-extend-rule')
 
 module.exports = {
   ignore: ['yarn.lock', '**/_*'],
-  entry: { 'js/main': './js/index.js' },
+  entry: { 'js/main': './js/index.js', 'js/analytics.js': './js/analytics.js' },
   postcss: cssStandards({
     appendPlugins: [extendRule()]
   }),

--- a/website/assets/js/analytics.js
+++ b/website/assets/js/analytics.js
@@ -1,0 +1,101 @@
+import { each } from './utils'
+
+/* Segment's analytics.js provides a ready() function that is called once tracking is up and running */
+/* Some clients block analytics.js, so to prevent errors, we assign noop functions if window.analytics isn't present */
+window.analytics.ready(() => {
+  const analytics = window.analytics || {
+    trackLink: () => {},
+    track: () => {},
+    mock: true
+  }
+
+  // Track all button clicks
+  track(
+    '[data-ga-button]',
+    el => {
+      return {
+        event: 'Click',
+        category: 'Button',
+        label: el.getAttribute('data-ga-button')
+      }
+    },
+    true
+  )
+
+  // Track product subnav link clicks
+  track(
+    '[data-ga-product-subnav]',
+    el => {
+      return {
+        event: 'Click',
+        category: 'Product Subnav Navigation',
+        label: el.getAttribute('data-ga-product-subnav')
+      }
+    },
+    true
+  )
+
+  // Track meganav link clicks
+  track(
+    '[data-ga-meganav]',
+    el => {
+      return {
+        event: 'Click',
+        category: 'Meganav Navigation',
+        label: el.getAttribute('data-ga-meganav')
+      }
+    },
+    true
+  )
+
+  // Track footer link clicks
+  track(
+    '[data-ga-footer]',
+    el => {
+      return {
+        event: 'Click',
+        category: 'Footer Navigation',
+        label: el.getAttribute('data-ga-footer')
+      }
+    },
+    true
+  )
+
+  // Track outbound links
+  track(
+    'a[href^="http"]:not([href^="http://vaultproject.io"]):not([href^="https://vaultproject.io"]):not([href^="http://www.vaultproject.io"]):not([href^="https://www.vaultproject.io"])',
+    el => {
+      return {
+        event: `Outbound Link | ${window.location.pathname}`,
+        category: 'Outbound link',
+        label: el.href
+      }
+    },
+    true
+  )
+
+  // Note: Downloads are tracked from within the Product Downloader component
+
+  /**
+   * Wrapper for segment's track function that will track multiple elements,
+   * normalize parameters, and easily switch between tracking links or events.
+   * @param  {String} selector - query selector, multi element compatible
+   * @param  {Function} cb - optional function that should return params, and will receive the element as a parameter
+   * @param  {Boolean} [link=false] - if true, tracks a link click
+   */
+  function track(selector, cb, link = false) {
+    each(document.querySelectorAll(selector), el => {
+      let params = cb
+      if (typeof cb === 'function') params = cb(el)
+      const event = params.event
+      delete params.event
+      if (link) {
+        analytics.trackLink(el, event, params)
+      } else {
+        el.addEventListener('click', () => {
+          analytics.track(event, params)
+        })
+      }
+    })
+  }
+})

--- a/website/assets/package.json
+++ b/website/assets/package.json
@@ -24,7 +24,7 @@
     "@hashicorp/hashi-nav": "1.1.1",
     "@hashicorp/hashi-newsletter-signup-form": "1.0.6",
     "@hashicorp/hashi-product-downloader": "^0.6.1",
-    "@hashicorp/hashi-product-subnav": "^0.5.1",
+    "@hashicorp/hashi-product-subnav": "^0.5.2",
     "@hashicorp/hashi-section-header": "2.0.3",
     "@hashicorp/hashi-split-cta": "^0.1.4",
     "@hashicorp/hashi-vertical-text-block-list": "^0.1.1",


### PR DESCRIPTION
Adds our usual analytics.js tracking for component and outbound links.

Something to consider: links to `hashicorp.com` would qualify as "outbound" here, which I'm not sure we want? Maybe something to check with Brandon about? Appreciate your thoughts here.

[Asana ticket](https://app.asana.com/0/346384260719996/888936229137779/f)

Depends on publishing updated version of `product-downloader` ([PR](https://github.com/hashicorp/web-components/pull/407)) and `product-subnav` ([PR](https://github.com/hashicorp/web-components/pull/410))