### PR TITLE
Swap CTA and docs sections

### DIFF
--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -20,6 +20,15 @@ description: "Vault secures, stores, and tightly controls access to tokens, pass
     <hashi-callouts _data="<%= encode(page.use_cases_callouts[0]) %>"></hashi-callouts>
   </section>
 
+  <section class='g-container'>
+    <hashi-section-header
+      headline="<%= page.documentation_headline.headline %>"
+      description="<%= page.documentation_headline.description %>"
+    ></hashi-section-header>
+
+    <hashi-linked-text-summary-list _data="<%= encode(data.docs_basic_categories) %>"></hashi-linked-text-summary-list>
+  </section>
+
   <section class='gray'>
     <div class='g-container'>
       <hashi-section-header
@@ -38,15 +47,6 @@ description: "Vault secures, stores, and tightly controls access to tokens, pass
         <% end %>
       </div>
     </div>
-  </section>
-
-  <section class='g-container'>
-    <hashi-section-header
-      headline="<%= page.documentation_headline.headline %>"
-      description="<%= page.documentation_headline.description %>"
-    ></hashi-section-header>
-
-    <hashi-linked-text-summary-list _data="<%= encode(data.docs_basic_categories) %>"></hashi-linked-text-summary-list>
   </section>
 
   <section class='no-pad'>


### PR DESCRIPTION
As requested by Mitchell via Marcel - see ticket: https://app.asana.com/0/346384260719996/891291170057957/f

We could make the Docs section gray to break things up, but we'd need to update the grid component (hover is white). Question for design?